### PR TITLE
Respect PULSE_SINK environment variable

### DIFF
--- a/src/src_pulse.c
+++ b/src/src_pulse.c
@@ -142,7 +142,8 @@ static void pulse_server_info_cb(pa_context *context, const pa_server_info *info
     PulseCtx *ctx = data;
 
     pa_operation *op;
-    op = pa_context_get_sink_info_by_name(context, info->default_sink_name,
+    char *default_sink = getenv("PULSE_SINK");
+    op = pa_context_get_sink_info_by_name(context, (default_sink != NULL) ? default_sink : info->default_sink_name,
                                           pulse_sink_info_cb, ctx);
     pa_operation_unref(op);
 }


### PR DESCRIPTION
This allows you to specify the pulseaudio sink wlstream uses before
recording starts.

For example, you want to record your screen without any audio:

```
pactl load-module module-null-sink
env PULSE_SINK=null wlstream 0 vaapi /dev/dri/renderD129 libx264 nv12 12 dmabuf_recording_01.mkv
```